### PR TITLE
chore: add kaniko label to agents

### DIFF
--- a/jenkins/values-agents.yaml
+++ b/jenkins/values-agents.yaml
@@ -3,7 +3,7 @@ jenkins:
     # This archetype agent gets used to inherit values but also serves as a standard builder
     podName: kaniko-precached-jdk11
     # Note that an additional "terajenkins-jenkins-agent" label gets added everywhere (podLabels thing?)
-    customJenkinsLabels: "kaniko-precached-jdk11 ts-engine ts-module lib heavy light java11"
+    customJenkinsLabels: "kaniko-precached-jdk11 ts-engine ts-module lib heavy light java11 light-java"
     nodeUsageMode: "EXCLUSIVE"
     sideContainerName: builder
     image: terasology/jenkins-precached-agent

--- a/jenkins/values-agents.yaml
+++ b/jenkins/values-agents.yaml
@@ -3,7 +3,7 @@ jenkins:
     # This archetype agent gets used to inherit values but also serves as a standard builder
     podName: kaniko-precached-jdk11
     # Note that an additional "terajenkins-jenkins-agent" label gets added everywhere (podLabels thing?)
-    customJenkinsLabels: "kaniko-precached-jdk11 ts-engine ts-module lib heavy light java11 light-java kaniko"
+    customJenkinsLabels: "kaniko-precached-jdk11 ts-engine ts-module lib heavy light java11 kaniko"
     nodeUsageMode: "EXCLUSIVE"
     sideContainerName: builder
     image: terasology/jenkins-precached-agent
@@ -24,5 +24,5 @@ jenkins:
   additionalAgents:
     kanikoEight:
       podName: kaniko-precached-jdk8
-      customJenkinsLabels: "kaniko-precached-jdk8 light-java kaniko"
+      customJenkinsLabels: "kaniko-precached-jdk8 kaniko"
       tag: latest-jdk8

--- a/jenkins/values-agents.yaml
+++ b/jenkins/values-agents.yaml
@@ -3,7 +3,7 @@ jenkins:
     # This archetype agent gets used to inherit values but also serves as a standard builder
     podName: kaniko-precached-jdk11
     # Note that an additional "terajenkins-jenkins-agent" label gets added everywhere (podLabels thing?)
-    customJenkinsLabels: "kaniko-precached-jdk11 ts-engine ts-module lib heavy light java11 light-java"
+    customJenkinsLabels: "kaniko-precached-jdk11 ts-engine ts-module lib heavy light java11 light-java kaniko"
     nodeUsageMode: "EXCLUSIVE"
     sideContainerName: builder
     image: terasology/jenkins-precached-agent
@@ -24,5 +24,5 @@ jenkins:
   additionalAgents:
     kanikoEight:
       podName: kaniko-precached-jdk8
-      customJenkinsLabels: "kaniko-precached-jdk8 light-java"
+      customJenkinsLabels: "kaniko-precached-jdk8 light-java kaniko"
       tag: latest-jdk8

--- a/jenkins/values-agents.yaml
+++ b/jenkins/values-agents.yaml
@@ -24,5 +24,5 @@ jenkins:
   additionalAgents:
     kanikoEight:
       podName: kaniko-precached-jdk8
-      customJenkinsLabels: "kaniko-precached-jdk8"
+      customJenkinsLabels: "kaniko-precached-jdk8 light-java"
       tag: latest-jdk8


### PR DESCRIPTION
In our old setup we had a jdk8 agent labelled with `light-java` and `kaniko` that was used, amongst others, by gestalt and JenkinsAndroidAgent builds. Now we have a jdk11 agent as default and an additional jdk8 agent, neither of which has the afore-mentioned labels.

As a result, build jobs on gestalt and JenkinsAndroidAgent cannot find an executor with the respective `light-java` or `kaniko` label.

The `light-java` label was superseded by the `light` label (which makes sense as light and java are two different dimensions), so we should not change this here, but instead adjust it on "consumer" side.
The `kaniko` label, however, should be added to allow identifying kaniko executors, especially if we might add other executors in the future. Also it doesn't really cost anything to add another label, does it?


Relates to https://github.com/MovingBlocks/gestalt/pull/137
Relates to https://github.com/MovingBlocks/JenkinsAgentAndroid/pull/3